### PR TITLE
unexpected comma, correct devnet version id

### DIFF
--- a/src/Builders/AbstractBuilder.php
+++ b/src/Builders/AbstractBuilder.php
@@ -32,7 +32,7 @@ abstract class AbstractBuilder
     /** @var array */
     protected $networks = [
         '6e84d08bd299ed97c212c886c98a57e36545c8f5d645ca7eeae63a8bd62d8988' => "0x17",
-        '578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23' => "0x30",
+        '578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23' => "0x1E",
         'd1c7fa0dcf7584add7a535acd674d3b13fa794345d83c3789cc2436d6ecd80d1' => "0x52",
     ];
 

--- a/src/Builders/templates/transaction.createTransaction
+++ b/src/Builders/templates/transaction.createTransaction
@@ -10,9 +10,9 @@ var transaction = ark.transaction.createTransaction(
     {% else %}
         null,
     {% endif %}
-    "{{ secret }}",
+    "{{ secret }}"
     {% if secondSecret %}
-    	"{{ secondSecret }}"
+    	,"{{ secondSecret }}"
     {% endif %}
 );
 


### PR DESCRIPTION
- src/Builders/templates/transaction.createTransaction:

Comma at the end broke it when there's no second passphrase:
```
>>> $transaction = Lark::api('Transaction')->create($recipient->address, 100, $recipient->smartbridge, $secret->value);
/home/munich/laravel/vendor/faustbrian/ark-php-client/src/Builders/transaction.createTransaction.js:10
    );
    ^

SyntaxError: Unexpected token )
```
- src/Builders/AbstractBuilder.php:
`0x30` doesn't work on the devnet:
```
/home/munich/laravel/node_modules/arkjs/lib/transactions/transaction.js:7
    throw new Error("Wrong recipientId");
    ^

Error: Wrong recipientId
```
`0x30` is 48 in decimal, the devnet version is 30, which is `0x1E` in hexadecimal.